### PR TITLE
Add missing generate both for truffle and update web3j to 4.12.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ mainClassName = 'org.web3j.console.Web3j'
 applicationName = 'web3j'
 
 ext {
-    web3jVersion = '4.12.2'
+    web3jVersion = '4.12.3'
     picocli = '4.7.6'
     slf4jVersion = '2.0.13'
     junitVersion = '5.9.3'

--- a/src/main/java/org/web3j/console/wrapper/subcommand/TruffleGenerateCommand.java
+++ b/src/main/java/org/web3j/console/wrapper/subcommand/TruffleGenerateCommand.java
@@ -69,6 +69,11 @@ public class TruffleGenerateCommand implements Runnable {
             description = "Use Solidity types.")
     private boolean solidityTypes;
 
+    @Option(
+            names = {"-B", "--generateBoth"},
+            description = "Generate both send_ and call_ functions.")
+    private boolean generateBoth = false;
+
     @Override
     public void run() {
 
@@ -76,11 +81,11 @@ public class TruffleGenerateCommand implements Runnable {
 
         try {
             new TruffleJsonFunctionWrapperGenerator(
-                            jsonFileLocation.getAbsolutePath(),
-                            destinationDirLocation.getAbsolutePath(),
-                            basePackageName,
-                            useJavaNativeTypes,
-                            true)
+                    jsonFileLocation.getAbsolutePath(),
+                    destinationDirLocation.getAbsolutePath(),
+                    basePackageName,
+                    useJavaNativeTypes,
+                    generateBoth)
                     .generate();
         } catch (Exception e) {
             Console.exitError(e);


### PR DESCRIPTION
Added the generateBoth parameter for the ‘TruffleGenerateCommand’ class, as it was added for ‘SolidityGenerateCommand’.

Updated the web3j version to 4.12.3.